### PR TITLE
Fixes FreshRSS API not exposing properly through reverse proxy

### DIFF
--- a/services/freshrss/nginx.conf.j2
+++ b/services/freshrss/nginx.conf.j2
@@ -10,7 +10,29 @@ server {
     include snippets/ssl.nginx.conf*;
 
     location / {
-        proxy_pass         http://$freshrss:80;
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable for ldap auth (requires ldap-server.conf in the server block)
+        #include /config/nginx/ldap-location.conf;
+
+        # enable for Authelia (requires authelia-server.conf in the server block)
+        #include /config/nginx/authelia-location.conf;
+
+        # enable for Authentik (requires authentik-server.conf in the server block)
+        #include /config/nginx/authentik-location.conf;
+
+        set $upstream_app freshrss;
+        set $upstream_port 80;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+
+        proxy_buffering off;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_cookie_path / "/; HTTPOnly; Secure";
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_header Authorization;
     }
 
     location /.well-known/acme-challenge/ {


### PR DESCRIPTION
Applies the config located [here](https://github.com/linuxserver/reverse-proxy-confs/blob/master/freshrss.subdomain.conf.sample). 